### PR TITLE
Fix integration tests and configure DI

### DIFF
--- a/src/RagService.Api/Program.cs
+++ b/src/RagService.Api/Program.cs
@@ -1,5 +1,10 @@
 var builder = WebApplication.CreateBuilder(args);
 
+// Application services
+builder.Services.AddSingleton<RagService.Application.Interfaces.IEmbeddingService, RagService.Infrastructure.Embeddings.MockEmbeddingService>();
+builder.Services.AddSingleton<RagService.Application.Interfaces.ILLMService, RagService.Infrastructure.Llm.MockLlmService>();
+builder.Services.AddSingleton<RagService.Application.Interfaces.IVectorSearchService, RagService.Infrastructure.VectorSearch.VectorSearchService>();
+
 // Add services to the container.
 
 builder.Services.AddControllers();

--- a/src/RagService.Api/RagService.Api.csproj
+++ b/src/RagService.Api/RagService.Api.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\RagService.Application\RagService.Application.csproj" />
+    <ProjectReference Include="..\RagService.Infrastructure\RagService.Infrastructure.csproj" />
   </ItemGroup>
   <ItemGroup>
   <None Include="data\**\*">

--- a/tests/RagService.Tests/Utilities/CustomWebAppFactory.cs
+++ b/tests/RagService.Tests/Utilities/CustomWebAppFactory.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using RagService.Api;
+using RagService.Application.Interfaces;
+using RagService.Infrastructure.Embeddings;
+using RagService.Infrastructure.Llm;
+
+namespace RagService.Tests.Utilities
+{
+    /// <summary>
+    /// Bootstraps the API for integration tests using in-memory mocks.
+    /// </summary>
+    public sealed class CustomWebAppFactory : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            var apiDir = Path.GetFullPath(Path.Combine(
+                AppContext.BaseDirectory,
+                "..", "..", "..", "..",
+                "..",
+                "src", "RagService.Api"));
+
+            builder.UseContentRoot(apiDir);
+
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll(typeof(IEmbeddingService));
+                services.RemoveAll(typeof(ILLMService));
+
+                services.AddSingleton<IEmbeddingService, MockEmbeddingService>();
+                services.AddSingleton<ILLMService, MockLlmService>();
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- register app services in Program.cs so the API can run
- build a CustomWebAppFactory that points to the API project and injects mock services
- rewrite `QueryControllerIntegrationTests` to use the factory
- reference infrastructure project from API project

## Testing
- `dotnet test` *(fails: `dotnet` not found)*